### PR TITLE
Make InternalClient stateless

### DIFF
--- a/src/main/scala/dynamodb/node/InternalClient.scala
+++ b/src/main/scala/dynamodb/node/InternalClient.scala
@@ -2,9 +2,9 @@ package dynamodb.node
 
 import akka.actor
 import akka.actor.typed.scaladsl.AskPattern._
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
-import akka.actor.typed.scaladsl.{AbstractBehavior, ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, ActorSystem, Behavior}
+import akka.actor.typed.{ActorRef, ActorSystem, Behavior, Scheduler}
 import akka.cluster.VectorClock
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.ContentTypes.`application/json`
@@ -22,52 +22,38 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 object InternalClient {
-  def apply(valueRepository: ActorRef[ValueRepository.Command], dht: ActorRef[DistributedHashTable.Command], host: String, port: Int, n: Int, r: Int, w: Int, nodeName: String): Behavior[Command] =
-    Behaviors.setup(context => new InternalClient(context, valueRepository, dht, host, port, n, r, w, nodeName))
+  def apply(host: String, port: Int, numNodes: Int, numReadMinimum: Int, numWriteMinimum: Int, nodeName: String)(implicit valueRepository: ActorRef[ValueRepository.Command], dht: ActorRef[DistributedHashTable.Command]): Behavior[Command] = Behaviors.receive { (context, command) =>
+    implicit val actorSystem: ActorSystem[Nothing] = context.system
+    implicit val classicActorSystem: actor.ActorSystem = context.system.toClassic
+    implicit val materializer: Materializer = Materializer(classicActorSystem)
+    implicit val timeout: Timeout = 5.seconds
 
-  // Trait defining responses
-  sealed trait Response
-
-  final case class ValueRes(value: ValueRepository.Value) extends Response
-
-  case object OK extends Response
-
-  case class KO(reason: String) extends Response
-
-  sealed trait Command
-
-  final case class Put(value: ValueRepository.Value, replyTo: ActorRef[Response]) extends Command
-
-  final case class Putted(replyTo: ActorRef[Response]) extends Command
-
-  final case class InternalClientFailure(replyTo: ActorRef[Response], reason: String) extends Command
-
-  final case class Get(key: String, replyTo: ActorRef[Response]) extends Command
-
-  final case class Retrieved(value: ValueRepository.Value, replyTo: ActorRef[Response]) extends Command
-
-  final case class Init(host: String, port: Int, n: Int, r: Int, w: Int) extends Command
-
-}
-
-
-class InternalClient(context: ActorContext[InternalClient.Command], valueRepository: ActorRef[ValueRepository.Command], dht: ActorRef[DistributedHashTable.Command], host: String, port: Int, n: Int, r: Int, w: Int, nodeName: String)
-  extends AbstractBehavior[InternalClient.Command](context) {
-
-  import InternalClient._
-  import JsonSupport._
-  import spray.json._
-
-  implicit val actorSystem: ActorSystem[Nothing] = context.system
-  implicit val classicActorSystem: actor.ActorSystem = context.system.toClassic
-  implicit val materializer: Materializer = Materializer(classicActorSystem)
-  implicit val timeout: Timeout = 5.seconds
-
-  var meHost: Uri = Uri.from(scheme = "http", host = host, port = port, path = "/internal")
-
-  var N: Int = n
-  var R: Int = r
-  var W: Int = w
+    command match {
+      case Put(value, replyTo) =>
+        context.pipeToSelf(write(value, nodeName, numNodes, numWriteMinimum)) {
+          case Success(true) => PutSuccess(replyTo)
+          case Success(false) => InternalClientFailure(replyTo, "Not enough writes")
+          case Failure(exception) => InternalClientFailure(replyTo, exception.getMessage)
+        }
+        Behaviors.same
+      case PutSuccess(replyTo) =>
+        replyTo ! OK
+        Behaviors.same
+      case InternalClientFailure(replyTo, reason) =>
+        replyTo ! KO(reason)
+        Behaviors.same
+      case RetrieveSuccess(value, replyTo) =>
+        replyTo ! ValueRes(value)
+        Behaviors.same
+      case Get(key, replyTo) =>
+        context.pipeToSelf(read(key, numNodes)) {
+          case Success(value) => RetrieveSuccess(value, replyTo)
+          case Failure(exception) => InternalClientFailure(replyTo, exception.getMessage)
+        }
+        Behaviors.same
+      case Init(host, port, n, r, w) => InternalClient(host, port, n, r, w, nodeName)
+    }
+  }
 
   /**
    * Method executed with get() operation
@@ -75,16 +61,19 @@ class InternalClient(context: ActorContext[InternalClient.Command], valueReposit
    * @param key the key to get
    * @return the value of that key
    */
-  def read(key: String): Future[ValueRepository.Value] = for {
+  def read(key: String, N: Int)(implicit actorSystem: actor.ActorSystem, dht: ActorRef[DistributedHashTable.Command], scheduler: Scheduler, timeout: Timeout, mat: Materializer): Future[ValueRepository.Value] = for {
     otherNodesOption <- dht.ask(GetTopN(DistributedHashTable.getHash(key), N, _: ActorRef[Option[LazyList[RingNode]]]))
-    otherNodes = otherNodesOption match {
-      case Some(otherNodes) => otherNodes
-      case _ => throw new Exception("Error getting top N nodes")
-    }
+    otherNodes = otherNodesOption.getOrElse(throw new Exception("Error getting top N nodes"))
     responses <- Future.sequence(otherNodes.map(n => getOtherNodes(key, Uri.from("http", "", n.host, n.port, "/internal/"))))
     successfulResponses = responses.filter(response => response.status == StatusCodes.OK)
-    versions <- Future.sequence(successfulResponses.map(Unmarshal(_).to[ValueRepository.Value]))
+    versions <- Future.sequence(successfulResponses.map(unmarshal))
   } yield checkVersion(versions.toList)
+
+  def unmarshal(response: HttpResponse)(implicit mat: Materializer): Future[ValueRepository.Value] = {
+    import JsonSupport._
+
+    Unmarshal(response).to[ValueRepository.Value]
+  }
 
   /**
    * Write value to other nodes
@@ -92,17 +81,15 @@ class InternalClient(context: ActorContext[InternalClient.Command], valueReposit
    * @param v value to write
    * @return True if written to W - 1 other nodes successfully, false otherwise
    */
-  def write(v: ValueRepository.Value): Future[Boolean] = for {
+  def write(v: ValueRepository.Value, nodeName: String, N: Int, W: Int)(implicit actorSystem: actor.ActorSystem, dht: ActorRef[DistributedHashTable.Command], valueRepository: ActorRef[ValueRepository.Command], timeout: Timeout, scheduler: Scheduler): Future[Boolean] = for {
     valueOption <- valueRepository.ask(GetValueByKey(v.key, _: ActorRef[Option[ValueRepository.Value]]))
     value = valueOption match {
       case Some(value) => ValueRepository.Value(v.key, v.value, value.version :+ nodeName)
       case None => ValueRepository.Value(v.key, v.value, new VectorClock(TreeMap(nodeName -> 0)))
     }
-    topN <- dht.ask(GetTopN(DistributedHashTable.getHash(value.key), N, _: ActorRef[Option[LazyList[RingNode]]]))
-    responses <- topN match {
-      case Some(topN) => Future.sequence(topN.map(node => putOtherNodes(value, Uri.from("http", "", node.host, node.port, "/internal"))))
-      case _ => throw new Exception("Error getting top N nodes")
-    }
+    otherNodesOption <- dht.ask(GetTopN(DistributedHashTable.getHash(value.key), N, _: ActorRef[Option[LazyList[RingNode]]]))
+    otherNodes = otherNodesOption.getOrElse(throw new Exception("Error getting top N nodes"))
+    responses <- Future.sequence(otherNodes.map(node => putOtherNodes(value, Uri.from("http", "", node.host, node.port, "/internal"))))
   } yield responses.count(r => r.status == StatusCodes.OK) >= W - 1
 
   /**
@@ -112,22 +99,24 @@ class InternalClient(context: ActorContext[InternalClient.Command], valueReposit
    * @param address address of the server
    * @return Http Response
    */
-  def getOtherNodes(key: String, address: Uri): Future[HttpResponse] = {
-    Http().singleRequest(
-      HttpRequest(uri = address + key))
+  def getOtherNodes[T](key: String, address: Uri)(implicit actorSystem: actor.ActorSystem): Future[HttpResponse] = {
+    Http().singleRequest(HttpRequest(uri = address + key))
   }
 
   /**
    *
-   * @param v       value to write
+   * @param value   value to write
    * @param address address of the server
    * @return
    */
-  def putOtherNodes(v: ValueRepository.Value, address: Uri): Future[HttpResponse] = {
+  def putOtherNodes(value: ValueRepository.Value, address: Uri)(implicit actorSystem: actor.ActorSystem): Future[HttpResponse] = {
+    import JsonSupport._
+    import spray.json._
+
     Http().singleRequest(HttpRequest(
       method = HttpMethods.POST,
       uri = address,
-      entity = HttpEntity(`application/json`, v.toJson.compactPrint)
+      entity = HttpEntity(`application/json`, value.toJson.compactPrint)
     ))
   }
 
@@ -147,48 +136,26 @@ class InternalClient(context: ActorContext[InternalClient.Command], valueReposit
     result
   }
 
-  /**
-   * Helper method to adjust parameters of the client
-   *
-   * @param h hostname
-   * @param p port
-   * @param n N value
-   * @param r R value
-   * @param w W value
-   */
-  def initParams(h: String, p: Int, n: Int, r: Int, w: Int): Unit = {
-    this.meHost = Uri.from(scheme = "http", host = h, port = p, path = "/internal")
-    this.N = n
-    this.R = r
-    this.W = w
-  }
+  // Trait defining responses
+  sealed trait Response
 
-  override def onMessage(msg: InternalClient.Command): Behavior[InternalClient.Command] = {
-    msg match {
-      case Put(value, replyTo) =>
-        context.pipeToSelf(write(value)) {
-          case Success(true) => Putted(replyTo)
-          case Success(false) => InternalClientFailure(replyTo, "Not enough writes")
-          case Failure(exception) => InternalClientFailure(replyTo, exception.getMessage)
-        }
-        Behaviors.same
-      case Putted(replyTo) =>
-        replyTo ! OK
-        Behaviors.same
-      case InternalClientFailure(replyTo, reason) =>
-        replyTo ! KO(reason)
-        Behaviors.same
-      case Retrieved(value, replyTo) =>
-        replyTo ! ValueRes(value)
-        Behaviors.same
-      case Get(key, replyTo) =>
-        context.pipeToSelf(read(key)) {
-          case Success(value) => Retrieved(value, replyTo)
-          case Failure(exception) => InternalClientFailure(replyTo, exception.getMessage)
-        }
-        Behaviors.same
-      case Init(h, p, n, r, w) => initParams(h, p, n, r, w)
-        this
-    }
-  }
+  sealed trait Command
+
+  final case class ValueRes(value: ValueRepository.Value) extends Response
+
+  case class KO(reason: String) extends Response
+
+  final case class Put(value: ValueRepository.Value, replyTo: ActorRef[Response]) extends Command
+
+  final case class PutSuccess(replyTo: ActorRef[Response]) extends Command
+
+  final case class InternalClientFailure(replyTo: ActorRef[Response], reason: String) extends Command
+
+  final case class Get(key: String, replyTo: ActorRef[Response]) extends Command
+
+  final case class RetrieveSuccess(value: ValueRepository.Value, replyTo: ActorRef[Response]) extends Command
+
+  final case class Init(host: String, port: Int, n: Int, r: Int, w: Int) extends Command
+
+  case object OK extends Response
 }

--- a/src/test/scala/dynamodb/node/HttpSpec.scala
+++ b/src/test/scala/dynamodb/node/HttpSpec.scala
@@ -23,9 +23,9 @@ class HttpSpec extends AnyWordSpec with BeforeAndAfterAll with Matchers with Sca
 
   override def createActorSystem(): actor.ActorSystem = testKit.system.toClassic
 
-  val valueRepository: ActorRef[ValueRepository.Command] = testKit.spawn(ValueRepository(""))
-  val dht: ActorRef[DistributedHashTable.Command] = testKit.spawn(DistributedHashTable())
-  val internalClient: ActorRef[InternalClient.Command] = testKit.spawn(InternalClient(valueRepository, dht, "", 0, 4, 3, 2, ""))
+  implicit val valueRepository: ActorRef[ValueRepository.Command] = testKit.spawn(ValueRepository(""))
+  implicit val dht: ActorRef[DistributedHashTable.Command] = testKit.spawn(DistributedHashTable())
+  val internalClient: ActorRef[InternalClient.Command] = testKit.spawn(InternalClient("", 0, 4, 3, 2, ""))
 
   lazy val routes: Route = new ExternalRoutes(valueRepository, internalClient).theValueRoutes
 
@@ -75,9 +75,9 @@ class HttpSpec extends AnyWordSpec with BeforeAndAfterAll with Matchers with Sca
       }
       val probe = testKit.createTestProbe[ValueRepository.Command]()
       val mockedPublisher = testKit.spawn(Behaviors.monitor(probe.ref, mockedBehavior))
-      val dht = testKit.spawn(DistributedHashTable())
+      implicit val dht: ActorRef[DistributedHashTable.Command] = testKit.spawn(DistributedHashTable())
 
-      val internalClient = testKit.spawn(InternalClient(valueRepository, dht, "", 0, 4, 2, 1, ""))
+      val internalClient = testKit.spawn(InternalClient("", 0, 4, 2, 1, ""))
       val routes = new ExternalRoutes(mockedPublisher, internalClient).theValueRoutes
 
       Delete("/values/myKey") ~> routes ~> check {
@@ -95,9 +95,9 @@ class HttpSpec extends AnyWordSpec with BeforeAndAfterAll with Matchers with Sca
       }
       val probe = testKit.createTestProbe[ValueRepository.Command]()
       val mockedPublisher = testKit.spawn(Behaviors.monitor(probe.ref, mockedBehavior))
-      val dht = testKit.spawn(DistributedHashTable())
+      implicit val dht: ActorRef[DistributedHashTable.Command] = testKit.spawn(DistributedHashTable())
 
-      val internalClient = testKit.spawn(InternalClient(valueRepository, dht, "", 0, 4, 2, 1, ""))
+      val internalClient = testKit.spawn(InternalClient("", 0, 4, 2, 1, ""))
 
       val routes = new ExternalRoutes(mockedPublisher, internalClient).theValueRoutes
 


### PR DESCRIPTION
Removes state from internal client, it uses a lot of implicits, not sure if I really like it. 