### PR TITLE
Timeouts after 1000 ms 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
   "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion,
   "com.typesafe.akka" %% "akka-cluster-typed" % akkaVersion,
+  "com.typesafe.akka" %% "akka-actor" % akkaVersion,
   "io.spray" %% "spray-json" % "1.3.5",
   "ch.qos.logback" % "logback-classic" % "1.1.3" % Runtime,
   "org.scalactic" %% "scalactic" % "3.1.1",

--- a/src/main/scala/dynamodb/node/ExternalServer.scala
+++ b/src/main/scala/dynamodb/node/ExternalServer.scala
@@ -19,6 +19,7 @@ object ExternalServer {
   final case class Started(binding: ServerBinding) extends Command
   final case class StartFailed(cause: Throwable) extends Command
   final case class Stop() extends  Command
+  final case class Sleep(millis: Int) extends Command
 }
 
 class ExternalServer(context: ActorContext[ExternalServer.Command], valueRepository: ActorRef[ValueRepository.Command], internalClient: ActorRef[InternalClient.Command], host: String, port: Int)
@@ -53,6 +54,10 @@ class ExternalServer(context: ActorContext[ExternalServer.Command], valueReposit
           binding.localAddress.getHostString,
           binding.localAddress.getPort)
 
+        this
+
+      case Sleep(x) =>
+        Thread.sleep(x)
         this
 
       case Stop() =>

--- a/src/main/scala/dynamodb/node/InternalServer.scala
+++ b/src/main/scala/dynamodb/node/InternalServer.scala
@@ -19,6 +19,7 @@ object InternalServer {
   final case class Started(binding: ServerBinding) extends Command
   final case class StartFailed(cause: Throwable) extends Command
   final case class Stop() extends Command
+  final case class Sleep(millis: Int) extends Command
 }
 
 class InternalServer(context: ActorContext[InternalServer.Command], valueRepository: ActorRef[ValueRepository.Command], host: String, port: Int)
@@ -53,6 +54,10 @@ class InternalServer(context: ActorContext[InternalServer.Command], valueReposit
           binding.localAddress.getHostString,
           binding.localAddress.getPort)
 
+        this
+
+      case Sleep(x) =>
+        Thread.sleep(x)
         this
 
       case Stop() =>

--- a/src/main/scala/dynamodb/node/Node.scala
+++ b/src/main/scala/dynamodb/node/Node.scala
@@ -14,6 +14,8 @@ object Node {
 
   sealed trait Message
 
+  final case class Sleep(millis: Int) extends Message
+
   private final case class StartFailed(cause: Throwable) extends Message
 
   private final case class Started(binding: ServerBinding) extends Message
@@ -25,6 +27,7 @@ object Node {
   private final case class StopExternal(binding: ServerBinding) extends Message
 
   case object Stop extends Message
+
 
   def apply(config: NodeConfig, allNodes: List[NodeConfig]): Behavior[Message] = Behaviors.setup { ctx =>
 
@@ -50,6 +53,10 @@ object Node {
 
     def starting(): Behaviors.Receive[Message] =
       Behaviors.receiveMessagePartial[Message] {
+        case Sleep(x) =>
+          internalServer ! InternalServer.Sleep(x)
+          externalServer ! ExternalServer.Sleep(x)
+          Behaviors.same
         case Stop =>
           internalServer ! InternalServer.Stop()
           externalServer ! ExternalServer.Stop()


### PR DESCRIPTION
When ` InternalClient ` sends out request to other nodes it should stop after 1000 ms and fail the write/read if there aren't enough succesful responses.

TODO: Fix test